### PR TITLE
Update modular.md

### DIFF
--- a/pages/01.home/modular.md
+++ b/pages/01.home/modular.md
@@ -24,7 +24,7 @@ form:
           label: Name
           classes: form-control
           placeholder: Enter your name
-          autofocus: on
+          autofocus: off
           autocomplete: on
           type: text
           position: left


### PR DESCRIPTION
Disable `autofocus` by default, as it causes a page-skip on initial load to the contact-form, skipping past most content on its way.